### PR TITLE
Downgrade required Argument Parser version

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
         .library(name: "PodfilerKit", targets: ["PodfilerKit"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-argument-parser", .upToNextMajor(from: "1.1.2")),
+        .package(url: "https://github.com/apple/swift-argument-parser", .upToNextMajor(from: "1.0.3")),
         .package(url: "https://github.com/apple/swift-tools-support-core", from: "0.1.10"),
         .package(url: "https://github.com/jpsim/Yams.git", .upToNextMajor(from: "4.0.6")),
     ],


### PR DESCRIPTION
I was too eager to jump straight to 1.1, turns out it's too new for [SwiftLint](https://github.com/realm/SwiftLint/blob/4382ef49b9af08cfc13cc145e206a63e89e03367/Package.swift#L35).

Note that I kept `upToNextMajor` (hence no `Package.resolved` changes) to avoid changing this line again when we move to Argument Parser 1.1.*.